### PR TITLE
backports-datetime-fromisoformat 2.0.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,14 +7,13 @@ package:
   version: {{ version }}
 
 source:
-  #url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name | lower }}-{{ version }}.tar.gz
   url: https://github.com/movermeyer/backports.datetime_fromisoformat/archive/refs/tags/v{{ version}}.tar.gz
   sha256: a0db0e99bdc33f7ebce1b73e19fca613f964b50d627bc69d11e90750dbdfe068
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+ 
 requirements:
   build:
     - {{ compiler('c') }}
@@ -25,19 +24,29 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - backports
     - backports.datetime_fromisoformat
   commands:
     - pip check
+    - pytest -vv .
   requires:
     - pip
+    - pytest
+    - pytz
 
 about:
   home: https://github.com/movermeyer/backports.datetime_fromisoformat
   summary: Backport of Python 3.7's datetime.fromisoformat
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  description: |
+    A backport of Python 3.11's datetime.fromisoformat methods to earlier versions of Python 3.
+  doc_url: https://github.com/movermeyer/backports.datetime_fromisoformat
+  dev_url: https://github.com/movermeyer/backports.datetime_fromisoformat
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "backports-datetime-fromisoformat" %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.3" %}
 
 
 package:
-  name: {{ name|lower }}
+  name: {{ name | lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1afaa4d593471a3b9a9875cc9b7edf2df8a4f317679ea658a8f8fa255539ce90
+  #url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name | lower }}-{{ version }}.tar.gz
+  url: https://github.com/movermeyer/backports.datetime_fromisoformat/archive/refs/tags/v{{ version}}.tar.gz
+  sha256: a0db0e99bdc33f7ebce1b73e19fca613f964b50d627bc69d11e90750dbdfe068
 
 build:
   number: 0
-  skip: true  # [py>=37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
backports-datetime-fromisoformat 2.0.3 

**Destination channel:** Defaults

### Links

- [PKG-8147]
- dev_url:        https://github.com/movermeyer/backports.datetime_fromisoformat/tree/v2.0.3
- conda_forge:    https://github.com/conda-forge/backports-datetime-fromisoformat-feedstock
- pypi:           https://pypi.org/project/backports-datetime-fromisoformat/2.0.3
- pypi inspector: https://inspector.pypi.io/project/backports-datetime-fromisoformat/2.0.3

### Related PRs:
- Dependency for:
    - https://github.com/AnacondaRecipes/marshmallow-feedstock/pull/7

### Explanation of changes:

- feedstock added to aggregate


[PKG-8147]: https://anaconda.atlassian.net/browse/PKG-8147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ